### PR TITLE
Add autodeploy and change a default URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    # See the following link for documentation:
+    # https://github.com/marketplace/actions/dokku
+    - name: Push to mjukglass
+      uses: dokku/github-action@v1.4.0
+      with:
+        ssh_private_key: ${{ secrets.MJUKGLASS_GLOBAL_DEPLOY_KEY }}
+        git_remote_url: ssh://dokku@mjukglass.datasektionen.se/styrdokument
+        # force might feel risky, but there is no good reason why the server
+        # should ever not be a mirror of the deploy branch. And the errors we
+        # could get otherwise would probably be nasty to deal with
+        git_push_flags: --force

--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ module.exports = {
     port: process.env.PORT || 5000,
 
     // Hostname of the Taitan instance, and whether to communicate over HTTPS with it
-    taitanUrl: process.env.TAITAN_URL || "https://taitan.datasektionen.se",
+    taitanUrl: process.env.TAITAN_URL || "http://styrdokument-taitan.mjukglass.datasektionen.se",
 
     // The name of the template engine as it's called by consolidate.js, may differ from extension
     // Default template file to look for in subdirectories

--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ module.exports = {
     port: process.env.PORT || 5000,
 
     // Hostname of the Taitan instance, and whether to communicate over HTTPS with it
-    taitanUrl: process.env.TAITAN_URL || "http://styrdokument-taitan.mjukglass.datasektionen.se",
+    taitanUrl: process.env.TAITAN_URL || "https://styrdokument-taitan.mjukglass.datasektionen.se",
 
     // The name of the template engine as it's called by consolidate.js, may differ from extension
     // Default template file to look for in subdirectories


### PR DESCRIPTION
I threw in a stashed url-change that I had. 

I kinda think it would more be reasonable to _not_ have these default urls, and have the application throw an error when running instead, but that is for another PR, and at least this url is _correct_, unlike previously.  (This is the url used by the server)